### PR TITLE
bump lean version

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -10,9 +10,12 @@ project. You can do that from the VSCode Lean menu or type in a terminal
 (do not use any fancy character in the name of your folder).
 
 Then you need to require the library in your lake file. 
-This means adding at the end of `lakefile.lean` in your project:
-```lean
-require verbose from git "https://github.com/PatrickMassot/verbose-lean4.git"
+This means adding at the end of `lakefile.toml` in your project:
+```
+[[require]]
+name = "verbose"
+git = "https://github.com/PatrickMassot/verbose-lean4.git"
+rev = "master"
 ```
 
 Important note in case you had an existing project: 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.10.0-rc2
+leanprover/lean4:v4.14.0


### PR DESCRIPTION
Verbose is pointing at a release candidate version of Lean. When, I try to use it I obtain an error, it seems to work with version 4.14.0.

