### PR TITLE
Get rid of automatic molecule splitting, and manually split them

### DIFF
--- a/Verbose/English/Assume.lean
+++ b/Verbose/English/Assume.lean
@@ -4,7 +4,7 @@ open Lean Elab Tactic
 
 syntax "Assume₁ " colGt assumeDecl : tactic
 syntax "Assume " "that"? (colGt assumeDecl)+ : tactic
-syntax "Assume " "for contradiction " (colGt assumeDecl) : tactic
+syntax "Assume " "for " "contradiction " (colGt assumeDecl) : tactic
 
 elab_rules : tactic
   | `(tactic| Assume₁ $x:ident) => Assume1 (introduced.bare x x.getId)

--- a/Verbose/English/By.lean
+++ b/Verbose/English/By.lean
@@ -4,16 +4,16 @@ import Verbose.English.Common
 open Lean Verbose.English
 
 
-elab "By " e:maybeApplied " we get " colGt news:newStuff : tactic => do
+elab "By " e:maybeApplied " we " "get " colGt news:newStuff : tactic => do
 obtainTac (← maybeAppliedToTerm e) (newStuffToArray news)
 
-elab "By " e:maybeApplied " we choose " colGt news:newStuff : tactic => do
+elab "By " e:maybeApplied " we " "choose " colGt news:newStuff : tactic => do
 chooseTac (← maybeAppliedToTerm e) (newStuffToArray news)
 
-elab "By " e:maybeApplied " it suffices to prove " "that "? colGt arg:term : tactic => do
+elab "By " e:maybeApplied " it " "suffices " "to " "prove " "that "? colGt arg:term : tactic => do
 bySufficesTac (← maybeAppliedToTerm e) #[arg]
 
-elab "By " e:maybeApplied " it suffices to prove " "that "? colGt args:sepBy(term, " and ") : tactic => do
+elab "By " e:maybeApplied " it " "suffices " "to " "prove " "that "? colGt args:sepBy(term, " and ") : tactic => do
 bySufficesTac (← maybeAppliedToTerm e) args.getElems
 
 lemma le_le_of_abs_le {α : Type*} [LinearOrderedAddCommGroup α] {a b : α} : |a| ≤ b → -b ≤ a ∧ a ≤ b := abs_le.1

--- a/Verbose/English/Calc.lean
+++ b/Verbose/English/Calc.lean
@@ -7,14 +7,14 @@ open Meta Verbose English
 
 declare_syntax_cat CalcFirstStep
 syntax ppIndent(colGe term (" from "  sepBy(maybeApplied, " and from "))?) : CalcFirstStep
-syntax ppIndent(colGe term (" by computation")?) : CalcFirstStep
+syntax ppIndent(colGe term (" by " "computation")?) : CalcFirstStep
 syntax ppIndent(colGe term (" since " facts)?) : CalcFirstStep
 syntax ppIndent(colGe term (" by " tacticSeq)?) : CalcFirstStep
 
 -- enforce indentation of calc steps so we know when to stop parsing them
 declare_syntax_cat CalcStep
 syntax ppIndent(colGe term " from " sepBy(maybeApplied, " and from ")) : CalcStep
-syntax ppIndent(colGe term " by computation") : CalcStep
+syntax ppIndent(colGe term " by " "computation") : CalcStep
 syntax ppIndent(colGe term " since " facts) : CalcStep
 syntax ppIndent(colGe term " by " tacticSeq) : CalcStep
 syntax CalcSteps := ppLine withPosition(CalcFirstStep) withPosition((ppLine linebreak CalcStep)*)

--- a/Verbose/English/Claim.lean
+++ b/Verbose/English/Claim.lean
@@ -11,7 +11,7 @@ open Lean Elab Tactic
 elab ("Fact" <|> "Claim") name:ident ":" stmt:term "from" prf:maybeApplied : tactic => do
   evalTactic (← `(tactic|have $name : $stmt := by We conclude by $prf))
 
-elab ("Fact" <|> "Claim") name:ident ":" stmt:term "by computation" : tactic => do
+elab ("Fact" <|> "Claim") name:ident ":" stmt:term "by " "computation" : tactic => do
   evalTactic (← `(tactic|have $name : $stmt := by We compute))
 
 example : 1 = 1 := by

--- a/Verbose/English/Common.lean
+++ b/Verbose/English/Common.lean
@@ -5,7 +5,7 @@ open Lean
 namespace Verbose.English
 
 declare_syntax_cat appliedTo
-syntax "applied to " sepBy(term, " and ") : appliedTo
+syntax "applied " "to " sepBy(term, " and ") : appliedTo
 
 def appliedToTerm : TSyntax `appliedTo → Array Term
 | `(appliedTo| applied to $[$args]and*) => args
@@ -13,7 +13,7 @@ def appliedToTerm : TSyntax `appliedTo → Array Term
 
 declare_syntax_cat usingStuff
 syntax " using " sepBy(term, " and ") : usingStuff
-syntax " using that " term : usingStuff
+syntax " using " "that " term : usingStuff
 
 def usingStuffToTerm : TSyntax `usingStuff → Array Term
 | `(usingStuff| using $[$args]and*) => args
@@ -44,8 +44,8 @@ def listTermToMaybeApplied : List Term → MetaM (TSyntax `maybeApplied)
 
 declare_syntax_cat newStuff
 syntax (ppSpace colGt maybeTypedIdent)* : newStuff
-syntax maybeTypedIdent "such that" ppSpace colGt maybeTypedIdent : newStuff
-syntax maybeTypedIdent "such that" ppSpace colGt maybeTypedIdent " and "
+syntax maybeTypedIdent "such " "that" ppSpace colGt maybeTypedIdent : newStuff
+syntax maybeTypedIdent "such " "that" ppSpace colGt maybeTypedIdent " and "
        ppSpace colGt maybeTypedIdent : newStuff
 
 def newStuffToArray : TSyntax `newStuff → Array MaybeTypedIdent
@@ -97,8 +97,8 @@ def newFactsToRCasesPatt : TSyntax `newFacts → RCasesPatt
 | _ => default
 
 declare_syntax_cat newObject
-syntax maybeTypedIdent "such that" maybeTypedIdent : newObject
-syntax maybeTypedIdent "such that" maybeTypedIdent colGt " and " maybeTypedIdent : newObject
+syntax maybeTypedIdent "such " "that" maybeTypedIdent : newObject
+syntax maybeTypedIdent "such " "that" maybeTypedIdent colGt " and " maybeTypedIdent : newObject
 
 def newObjectToTerm : TSyntax `newObject → MetaM Term
 | `(newObject| $x:maybeTypedIdent such that $new) => do

--- a/Verbose/English/ExampleLib.lean
+++ b/Verbose/English/ExampleLib.lean
@@ -7,17 +7,24 @@ def continuous_function_at (f : ℝ → ℝ) (x₀ : ℝ) :=
 def sequence_tendsto (u : ℕ → ℝ) (l : ℝ) :=
 ∀ ε > 0, ∃ N, ∀ n ≥ N, |u n - l| ≤ ε
 
-notation3:50 f:80 " is continuous at " x₀ => continuous_function_at f x₀
-notation3:50 u:80 " converges to " l => sequence_tendsto u l
+notation3:50 f:80 " is " "continuous " " at " x₀ => continuous_function_at f x₀
+notation3:50 u:80 " converges " "to " l => sequence_tendsto u l
 
 def increasing_seq (u : ℕ → ℝ) := ∀ n m, n ≤ m → u n ≤ u m
 
-notation3 u " is increasing" => increasing_seq u
+notation3 u " is " "increasing" => increasing_seq u
 
 def is_supremum (M : ℝ) (u : ℕ → ℝ) :=
 (∀ n, u n ≤ M) ∧ ∀ ε > 0, ∃ n₀, u n₀ ≥ M - ε
 
-notation3 M " is a supremum of " u => is_supremum M u
+syntax term " is " &"a " "supremum " "of " term : term
+macro_rules
+  | `($M is a supremum of $u) => `(is_supremum $M $u)
+@[app_unexpander is_supremum]
+def is_supremum.unexpand : Lean.PrettyPrinter.Unexpander
+  | `($(_) $M $u) => `($M is a supremum of $u)
+  | _ => throw ()
+
 
 configureUnfoldableDefs continuous_function_at sequence_tendsto increasing_seq is_supremum
 

--- a/Verbose/English/Lets.lean
+++ b/Verbose/English/Lets.lean
@@ -1,12 +1,12 @@
 import Verbose.Tactics.Lets
 import Mathlib.Tactic.Linarith
 
-elab "Let's" " prove by induction" name:ident ":" stmt:term : tactic =>
+elab "Let's" " prove " "by " "induction" name:ident ":" stmt:term : tactic =>
 letsInduct name.getId stmt
 
 open Lean Elab Tactic in
 
-macro "Let's" " prove that " stmt:term :tactic =>
+macro "Let's" " prove " "that " stmt:term :tactic =>
 `(tactic| first | show $stmt | apply Or.inl; show $stmt | apply Or.inr; show $stmt)
 
 declare_syntax_cat explicitStmtEN
@@ -14,16 +14,16 @@ syntax ": " term : explicitStmtEN
 
 def toStmt (e : Lean.TSyntax `explicitStmtEN) : Lean.Term := ⟨e.raw[1]!⟩
 
-elab "Let's" " prove that " witness:term " works" stmt:(explicitStmtEN)?: tactic => do
+elab "Let's" " prove " "that " witness:term " works" stmt:(explicitStmtEN)?: tactic => do
   useTac witness (stmt.map toStmt)
 
-elab "Let's" " first prove that " stmt:term : tactic =>
+elab "Let's" " first " "prove " "that " stmt:term : tactic =>
   anonymousSplitLemmaTac stmt
 
-elab "Let's" " now prove that " stmt:term : tactic =>
+elab "Let's" " now" " prove" " that " stmt:term : tactic =>
   unblockTac stmt
 
-syntax "You need to announce: Let's now prove that " term : term
+syntax "You " "need " "to " "announce: " "Let's " "now " "prove " "that " term : term
 
 open Lean Parser Term PrettyPrinter Delaborator in
 @[delab app.goalBlocker]
@@ -31,7 +31,7 @@ def goalBlocker_delab : Delab := whenPPOption Lean.getPPNotation do
   let stx ← SubExpr.withAppArg delab
   `(You need to announce: Let's now prove that $stx)
 
-macro "Let's" " prove it's contradictory" : tactic => `(tactic|exfalso)
+macro "Let's" " prove " "it's " "contradictory" : tactic => `(tactic|exfalso)
 
 open Lean
 

--- a/Verbose/English/Since.lean
+++ b/Verbose/English/Since.lean
@@ -6,29 +6,29 @@ namespace Verbose.English
 
 open Lean Elab Tactic
 
-elab "Since " facts:facts " we get " news:newObject : tactic => do
+elab "Since " facts:facts " we " &"get " news:newObject : tactic => do
   let newsT ← newObjectToTerm news
   let news_patt := newObjectToRCasesPatt news
   let factsT := factsToArray facts
   sinceObtainTac newsT news_patt factsT
 
-elab "Since " facts:facts " we get " news:newFacts : tactic => do
+elab "Since " facts:facts " we " &"get " news:newFacts : tactic => do
   let newsT ← newFactsToTypeTerm news
   let news_patt := newFactsToRCasesPatt news
   let factsT := factsToArray facts
   sinceObtainTac newsT news_patt factsT
 
-elab "Since " facts:facts " we conclude that " concl:term : tactic => do
+elab "Since " facts:facts " we " &"conclude " &"that " concl:term : tactic => do
   let factsT := factsToArray facts
   -- dbg_trace "factsT {factsT}"
   sinceConcludeTac concl factsT
 
-elab "Since " facts:facts " it suffices to prove " " that " newGoals:facts : tactic => do
+elab "Since " facts:facts " it " "suffices " &"to " "prove " &" that " newGoals:facts : tactic => do
   let factsT := factsToArray facts
   let newGoalsT := factsToArray newGoals
   sinceSufficesTac factsT newGoalsT
 
-elab "We discuss depending on whether " factL:term " or " factR:term : tactic => do
+elab "We " "discuss " "depending " &"on " "whether " factL:term " or " factR:term : tactic => do
   -- dbg_trace s!"factL {factL}"
   -- dbg_trace s!"factR {factR}"
   sinceDiscussTac factL factR

--- a/Verbose/English/We.lean
+++ b/Verbose/English/We.lean
@@ -4,26 +4,30 @@ import Verbose.English.Common
 open Lean Elab Parser Tactic Verbose.English
 
 declare_syntax_cat becomesEN
-syntax colGt " which becomes " term : becomesEN
+syntax colGt " which " "becomes " term : becomesEN
 
-def extractBecomes (e : Lean.TSyntax `becomesEN) : Lean.Term := ⟨e.raw[1]!⟩
+def extractBecomes (e : Lean.TSyntax `becomesEN) : Lean.Term :=
+  if let `(becomesEN|which becomes $t) := e then
+    t
+  else
+    panic! s!"Didn't recognize 'becomesEN' syntax: {e}"
 
-elab rw:"We" " rewrite using " s:myRwRuleSeq l:(location)? new:(becomesEN)? : tactic => do
+elab rw:"We" " rewrite " "using " s:myRwRuleSeq l:(location)? new:(becomesEN)? : tactic => do
   rewriteTac rw s (l.map expandLocation) (new.map extractBecomes)
 
-elab rw:"We" " rewrite using " s:myRwRuleSeq " everywhere" : tactic => do
+elab rw:"We" " rewrite " "using " s:myRwRuleSeq " everywhere" : tactic => do
   rewriteTac rw s (some Location.wildcard) none
 
-elab "We" " proceed using " exp:term : tactic =>
+elab "We" " proceed " "using " exp:term : tactic =>
   discussOr exp
 
-elab "We" " proceed depending on " exp:term : tactic =>
+elab "We" " proceed " "depending " "on " exp:term : tactic =>
   discussEm exp
 
 implement_endpoint (lang := en) cannotConclude : CoreM String :=
 pure "This does not conclude."
 
-elab "We" " conclude by " e:maybeApplied : tactic => do
+elab "We" " conclude " "by " e:maybeApplied : tactic => do
   concludeTac (← maybeAppliedToTerm e)
 
 elab "We" " combine " prfs:sepBy(term, " and ") : tactic => do
@@ -63,7 +67,7 @@ elab "We" " contrapose" : tactic => contraposeTac true
 
 elab "We" " contrapose" " simply": tactic => contraposeTac false
 
-elab "We " " push the negation " l:(location)? new:(becomesEN)? : tactic => do
+elab "We " " push " "the " "negation " l:(location)? new:(becomesEN)? : tactic => do
   pushNegTac (l.map expandLocation) (new.map extractBecomes)
 
 implement_endpoint (lang := en) rwResultWithoutGoal : CoreM String :=

--- a/Verbose/French/Assume.lean
+++ b/Verbose/French/Assume.lean
@@ -4,7 +4,7 @@ open Lean Elab Tactic
 
 syntax "Supposons₁ " colGt assumeDecl : tactic
 syntax "Supposons " "que"? (colGt assumeDecl)+ : tactic
-syntax "Supposons " "par l'absurde " (colGt assumeDecl) : tactic
+syntax "Supposons " &"par " " l'absurde " (colGt assumeDecl) : tactic
 
 elab_rules : tactic
   | `(tactic| Supposons₁ $x:ident) => Assume1 (introduced.bare x x.getId)

--- a/Verbose/French/By.lean
+++ b/Verbose/French/By.lean
@@ -5,16 +5,16 @@ namespace Verbose.French
 
 open Lean Elab Tactic
 
-elab "Par " e:maybeAppliedFR " on obtient " colGt news:newStuffFR : tactic => do
+elab "Par " e:maybeAppliedFR " on " " obtient " colGt news:newStuffFR : tactic => do
 obtainTac (← maybeAppliedFRToTerm e) (newStuffFRToArray news)
 
-elab "Par " e:maybeAppliedFR " on choisit " colGt news:newStuffFR : tactic => do
+elab "Par " e:maybeAppliedFR " on " " choisit " colGt news:newStuffFR : tactic => do
 chooseTac (← maybeAppliedFRToTerm e) (newStuffFRToArray news)
 
-elab "Par " e:maybeAppliedFR " il suffit de montrer " "que "? colGt arg:term : tactic => do
+elab "Par " e:maybeAppliedFR " il " " suffit" " de " " montrer " "que "? colGt arg:term : tactic => do
 bySufficesTac (← maybeAppliedFRToTerm e) #[arg]
 
-elab "Par " e:maybeAppliedFR " il suffit de montrer " "que "? colGt args:sepBy(term, " et ") : tactic => do
+elab "Par " e:maybeAppliedFR " il " " suffit " " de " " montrer " "que "? colGt args:sepBy(term, " et ") : tactic => do
 bySufficesTac (← maybeAppliedFRToTerm e) args.getElems
 
 lemma le_le_of_abs_le {α : Type*} [LinearOrderedAddCommGroup α] {a b : α} : |a| ≤ b → -b ≤ a ∧ a ≤ b := abs_le.1

--- a/Verbose/French/Calc.lean
+++ b/Verbose/French/Calc.lean
@@ -7,14 +7,14 @@ open Meta Verbose French
 
 declare_syntax_cat CalcFirstStepFR
 syntax ppIndent(colGe term (" par " sepBy(maybeAppliedFR, " et par "))?) : CalcFirstStepFR
-syntax ppIndent(colGe term (" par calcul")?) : CalcFirstStepFR
+syntax ppIndent(colGe term (" par " " calcul")?) : CalcFirstStepFR
 syntax ppIndent(colGe term (" puisque " factsFR)?) : CalcFirstStepFR
 syntax ppIndent(colGe term (" car " tacticSeq)?) : CalcFirstStepFR
 
 -- Note: need to repeat "par" in first form since "et" can appear in maybeAppliedFR
 declare_syntax_cat CalcStepFR
 syntax ppIndent(colGe term " par " sepBy(maybeAppliedFR, " et par ")) : CalcStepFR
-syntax ppIndent(colGe term " par calcul") : CalcStepFR
+syntax ppIndent(colGe term " par " " calcul") : CalcStepFR
 syntax ppIndent(colGe term " puisque " factsFR) : CalcStepFR
 syntax ppIndent(colGe term " car " tacticSeq) : CalcStepFR
 syntax CalcStepFRs := ppLine withPosition(CalcFirstStepFR) withPosition((ppLine linebreak CalcStepFR)*)

--- a/Verbose/French/Claim.lean
+++ b/Verbose/French/Claim.lean
@@ -13,7 +13,7 @@ open Lean Elab Tactic
 macro ("Fait" <|> "Affirmation") name:ident ":" stmt:term "par" prf:maybeAppliedFR : tactic =>
   `(tactic|have $name : $stmt := by On conclut par $prf)
 
-macro ("Fait" <|> "Affirmation") name:ident ":" stmt:term "par calcul" : tactic =>
+macro ("Fait" <|> "Affirmation") name:ident ":" stmt:term "par " " calcul" : tactic =>
   `(tactic|have $name : $stmt := by On calcule)
 
 example : 1 = 1 := by

--- a/Verbose/French/Common.lean
+++ b/Verbose/French/Common.lean
@@ -5,15 +5,15 @@ open Lean
 namespace Verbose.French
 
 declare_syntax_cat appliedToFR
-syntax "appliqué à " sepBy(term, " et ") : appliedToFR
+syntax "appliqué " " à " sepBy(term, " et ") : appliedToFR
 
 def appliedToFRTerm : TSyntax `appliedToFR → Array Term
 | `(appliedToFR| appliqué à $[$args]et*) => args
 | _ => default -- This will never happen as long as nobody extends appliedTo
 
 declare_syntax_cat usingStuffFR
-syntax " en utilisant " sepBy(term, " et ") : usingStuffFR
-syntax " en utilisant que " term : usingStuffFR
+syntax " en " " utilisant " sepBy(term, " et ") : usingStuffFR
+syntax " en " " utilisant " " que " term : usingStuffFR
 
 def usingStuffFRToTerm : TSyntax `usingStuffFR → Array Term
 | `(usingStuffFR| en utilisant $[$args]et*) => args
@@ -44,8 +44,8 @@ def listTermToMaybeApplied : List Term → MetaM (TSyntax `maybeAppliedFR)
 
 declare_syntax_cat newStuffFR
 syntax (ppSpace colGt maybeTypedIdent)* : newStuffFR
-syntax maybeTypedIdent "tel que" ppSpace colGt maybeTypedIdent : newStuffFR
-syntax maybeTypedIdent "tel que" ppSpace colGt maybeTypedIdent " et " ppSpace colGt maybeTypedIdent : newStuffFR
+syntax maybeTypedIdent "tel " " que" ppSpace colGt maybeTypedIdent : newStuffFR
+syntax maybeTypedIdent "tel " " que" ppSpace colGt maybeTypedIdent " et " ppSpace colGt maybeTypedIdent : newStuffFR
 
 def newStuffFRToArray : TSyntax `newStuffFR → Array MaybeTypedIdent
 | `(newStuffFR| $news:maybeTypedIdent*) => Array.map toMaybeTypedIdent news
@@ -96,8 +96,8 @@ def newFactsFRToRCasesPatt : TSyntax `newFactsFR → RCasesPatt
 | _ => default
 
 declare_syntax_cat newObjectFR
-syntax maybeTypedIdent "tel que" maybeTypedIdent : newObjectFR
-syntax maybeTypedIdent "tel que" maybeTypedIdent colGt " et " maybeTypedIdent : newObjectFR
+syntax maybeTypedIdent "tel " " que" maybeTypedIdent : newObjectFR
+syntax maybeTypedIdent "tel " " que" maybeTypedIdent colGt " et " maybeTypedIdent : newObjectFR
 
 def newObjectFRToTerm : TSyntax `newObjectFR → MetaM Term
 | `(newObjectFR| $x:maybeTypedIdent tel que $new) => do

--- a/Verbose/French/ExampleLib.lean
+++ b/Verbose/French/ExampleLib.lean
@@ -7,17 +7,17 @@ def continue_en (f : ℝ → ℝ) (x₀ : ℝ) :=
 def tend_vers (u : ℕ → ℝ) (l : ℝ) :=
 ∀ ε > 0, ∃ N, ∀ n ≥ N, |u n - l| ≤ ε
 
-notation3:50 f:80 " est continue en " x₀ => continue_en f x₀
-notation3:50 u:80 " tend vers " l => tend_vers u l
+notation3:50 f:80 " est " "continue " "en " x₀ => continue_en f x₀
+notation3:50 u:80 " tend " "vers " l => tend_vers u l
 
 def suite_croissante (u : ℕ → ℝ) := ∀ n m, n ≤ m → u n ≤ u m
 
-notation3 u " est croissante" => suite_croissante u
+notation3 u " est " "croissante" => suite_croissante u
 
 def est_sup (M : ℝ) (u : ℕ → ℝ) :=
 (∀ n, u n ≤ M) ∧ ∀ ε > 0, ∃ n₀, u n₀ ≥ M - ε
 
-notation3 M " est un supremum de " u => est_sup M u
+notation3 M " est " "un " "supremum " "de " u => est_sup M u
 
 configureUnfoldableDefs continue_en tend_vers suite_croissante est_sup
 

--- a/Verbose/French/Lets.lean
+++ b/Verbose/French/Lets.lean
@@ -3,7 +3,7 @@ import Mathlib.Tactic.Linarith
 
 namespace Verbose.French
 
-elab "Montrons" " par récurrence" name:ident ":" stmt:term : tactic =>
+elab "Montrons" &" par " " récurrence" name:ident ":" stmt:term : tactic =>
 letsInduct name.getId stmt
 
 open Lean Elab Tactic in
@@ -19,13 +19,13 @@ def toStmt (e : Lean.TSyntax `explicitStmtFR) : Lean.Term := ⟨e.raw[1]!⟩
 elab "Montrons" " que " witness:term " convient" stmt:(explicitStmtFR)?: tactic => do
   useTac witness (stmt.map toStmt)
 
-elab "Montrons" " d'abord que " stmt:term : tactic =>
+elab "Montrons" " d'abord " " que " stmt:term : tactic =>
   anonymousSplitLemmaTac stmt
 
-elab "Montrons" " maintenant que " stmt:term : tactic =>
+elab "Montrons" " maintenant " " que " stmt:term : tactic =>
   unblockTac stmt
 
-syntax "Vous devez annoncer: Montrons maintenant que " term : term
+syntax "Vous " " devez " " annoncer: " " Montrons " " maintenant " " que " term : term
 
 open Lean Parser Term PrettyPrinter Delaborator in
 @[delab app.goalBlocker]
@@ -33,7 +33,7 @@ def goalBlocker_delab : Delab := whenPPOption Lean.getPPNotation do
   let stx ← SubExpr.withAppArg delab
   `(Vous devez annoncer: Montrons maintenant que $stx)
 
-macro "Montrons" " une contradiction" : tactic => `(tactic|exfalso)
+macro "Montrons" &" une " " contradiction" : tactic => `(tactic|exfalso)
 
 open Lean
 

--- a/Verbose/French/Since.lean
+++ b/Verbose/French/Since.lean
@@ -6,13 +6,13 @@ namespace Verbose.French
 
 open Lean Elab Tactic
 
-elab "Comme " facts:factsFR " on obtient " news:newObjectFR : tactic => do
+elab "Comme " facts:factsFR " on " " obtient " news:newObjectFR : tactic => do
   let newsT ← newObjectFRToTerm news
   let news_patt := newObjectFRToRCasesPatt news
   let factsT := factsFRToArray facts
   sinceObtainTac newsT news_patt factsT
 
-elab "Comme " facts:factsFR " on obtient " news:newFactsFR : tactic => do
+elab "Comme " facts:factsFR " on " " obtient " news:newFactsFR : tactic => do
   let newsT ← newFactsFRToTypeTerm news
   -- dbg_trace "newsT {newsT}"
   let news_patt := newFactsFRToRCasesPatt news
@@ -20,17 +20,17 @@ elab "Comme " facts:factsFR " on obtient " news:newFactsFR : tactic => do
   -- dbg_trace "factsT {factsT}"
   sinceObtainTac newsT news_patt factsT
 
-elab "Comme " facts:factsFR " on conclut que " concl:term : tactic => do
+elab "Comme " facts:factsFR " on " " conclut " " que " concl:term : tactic => do
   let factsT := factsFRToArray facts
   -- dbg_trace "factsT {factsT}"
   sinceConcludeTac concl factsT
 
-elab "Comme " facts:factsFR " il suffit de montrer " " que " newGoals:factsFR : tactic => do
+elab "Comme " facts:factsFR " il " " suffit " " de " " montrer " " que " newGoals:factsFR : tactic => do
   let factsT := factsFRToArray facts
   let newGoalsT := factsFRToArray newGoals
   sinceSufficesTac factsT newGoalsT
 
-elab "On discute selon que " factL:term " ou " factR:term : tactic => do
+elab "On " " discute " " selon " " que " factL:term " ou " factR:term : tactic => do
   -- dbg_trace s!"factL {factL}"
   -- dbg_trace s!"factR {factR}"
   sinceDiscussTac factL factR

--- a/Verbose/French/Statements.lean
+++ b/Verbose/French/Statements.lean
@@ -13,15 +13,15 @@ Lean.TSyntax.mkInfoCanonical <$> `(tactic| with_suggestions $prf)
 /- **TODO**  Allow omitting Données or Hypothèses. -/
 
 elab ("Exercice"<|>"Exemple") str
-    "Données :" objs:bracketedBinder*
-    "Hypothèses :" hyps:bracketedBinder*
-    "Conclusion :" concl:term
-    tkp:"Démonstration :" prf?:(tacticSeq)? tkq:"QED" : command => do
+    "Données " ":" objs:bracketedBinder*
+    "Hypothèses " ":" hyps:bracketedBinder*
+    "Conclusion " ":" concl:term
+    tkp:"Démonstration " ":" prf?:(tacticSeq)? tkq:"QED" : command => do
   mkExercise none objs hyps concl prf? tkp tkq
 
 elab ("Exercice-lemme"<|>"Lemme") name:ident str
-    "Données :" objs:bracketedBinder*
-    "Hypothèses :" hyps:bracketedBinder*
-    "Conclusion :" concl:term
-    tkp:"Démonstration :" prf?:(tacticSeq)? tkq:"QED" : command => do
+    "Données " ":" objs:bracketedBinder*
+    "Hypothèses " ":" hyps:bracketedBinder*
+    "Conclusion " ":" concl:term
+    tkp:"Démonstration " ":" prf?:(tacticSeq)? tkq:"QED" : command => do
   mkExercise (some name) objs hyps concl prf? tkp tkq


### PR DESCRIPTION
I went in and manually split them, rather than having a macro do it. The project builds for me now, and clicking around in the example files seems to work, but I'm not sure if there's other things that need testing. Please let me know!

I set `a` to be a non-reserved keyword. Are there others that we should make sure don't get captured?