### PR TITLE
Alternative approach to non-reserved tokens

### DIFF
--- a/Verbose/English/ExampleLib.lean
+++ b/Verbose/English/ExampleLib.lean
@@ -7,17 +7,17 @@ def continuous_function_at (f : ℝ → ℝ) (x₀ : ℝ) :=
 def sequence_tendsto (u : ℕ → ℝ) (l : ℝ) :=
 ∀ ε > 0, ∃ N, ∀ n ≥ N, |u n - l| ≤ ε
 
-notation3:50 f:80 " is continuous at " x₀ => continuous_function_at f x₀
-notation3:50 u:80 " converges to " l => sequence_tendsto u l
+notation:50 f:80 " is continuous at " x₀ => continuous_function_at f x₀
+notation:50 u:80 " converges to " l => sequence_tendsto u l
 
 def increasing_seq (u : ℕ → ℝ) := ∀ n m, n ≤ m → u n ≤ u m
 
-notation3 u " is increasing" => increasing_seq u
+notation u " is increasing" => increasing_seq u
 
 def is_supremum (M : ℝ) (u : ℕ → ℝ) :=
 (∀ n, u n ≤ M) ∧ ∀ ε > 0, ∃ n₀, u n₀ ≥ M - ε
 
-notation3 M " is a supremum of " u => is_supremum M u
+notation M " is a supremum of " u => is_supremum M u
 
 configureUnfoldableDefs continuous_function_at sequence_tendsto increasing_seq is_supremum
 

--- a/Verbose/French/ExampleLib.lean
+++ b/Verbose/French/ExampleLib.lean
@@ -7,17 +7,17 @@ def continue_en (f : ℝ → ℝ) (x₀ : ℝ) :=
 def tend_vers (u : ℕ → ℝ) (l : ℝ) :=
 ∀ ε > 0, ∃ N, ∀ n ≥ N, |u n - l| ≤ ε
 
-notation3:50 f:80 " est continue en " x₀ => continue_en f x₀
-notation3:50 u:80 " tend vers " l => tend_vers u l
+notation:50 f:80 " est continue en " x₀ => continue_en f x₀
+notation:50 u:80 " tend vers " l => tend_vers u l
 
 def suite_croissante (u : ℕ → ℝ) := ∀ n m, n ≤ m → u n ≤ u m
 
-notation3 u " est croissante" => suite_croissante u
+notation u " est croissante" => suite_croissante u
 
 def est_sup (M : ℝ) (u : ℕ → ℝ) :=
 (∀ n, u n ≤ M) ∧ ∀ ε > 0, ∃ n₀, u n₀ ≥ M - ε
 
-notation3 M " est un supremum de " u => est_sup M u
+notation M " est un supremum de " u => est_sup M u
 
 configureUnfoldableDefs continue_en tend_vers suite_croissante est_sup
 


### PR DESCRIPTION
This version uses an explicit list of tokens to not reserve when splitting atoms at whitespace. See `dontReserve` in `Verbose/Tactics/Common.lean`.