### PR TITLE
Add simple build action

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -1,0 +1,18 @@
+name: Lean Action CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read # Read access to repository contents
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: leanprover/lean-action@v1


### PR DESCRIPTION
Just added the lean action, which effectively just runs `lake build` in this context. (It could also run lint and test if we configured it).

Example runs can be found [here](https://github.com/pimotte/verbose-lean4-testrepo/actions). It should work on this repo after being merged to master.