### PR TITLE
Fix typo(s) around anonymous compute lemmas in Extension infrastructure

### DIFF
--- a/Verbose/Infrastructure/Extension.lean
+++ b/Verbose/Infrastructure/Extension.lean
@@ -103,13 +103,21 @@ elab doc:(docComment)?
 
 registerDeclListExtension anonymousComputeLemmasListsExt
 
-/-- Print all registered anonymous split lemmas lists for debugging purposes. -/
-elab "#anonymous_goal_splitting_lemmas_lists" : command => do
+/-- Print all registered anonymous compute lemmas lists for debugging purposes. -/
+elab "#anonymous_compute_lemmas_lists" : command => do
   anonymousComputeLemmasListsExt.printDeclList
 
-/-- Register a list of anonymous split lemmas. -/
+/-- Register a list of anonymous compute lemmas. -/
 elab doc:(docComment)?
-    "AnonymousComputeLemmasLemmasList" name:ident ":=" args:ident* : command =>
+    "AnonymousComputeLemmasList" name:ident ":=" args:ident* : command =>
+  anonymousComputeLemmasListsExt.defineDeclList doc name args
+
+-- /-- Register a list of anonymous compute lemmas. -/
+-- /-- Kept for backwards compatibility -/
+elab doc:(docComment)?
+    "AnonymousComputeLemmasLemmasList" name:ident ":=" args:ident* : command => do
+  logWarning ("AnonymousComputeLemmasLemmasList is deprecated, " ++
+    "use AnonymousComputeLemmasList instead")
   anonymousComputeLemmasListsExt.defineDeclList doc name args
 
 /-! ##  Unfoldable definitions lists extension -/

--- a/Verbose/Infrastructure/Extension.lean
+++ b/Verbose/Infrastructure/Extension.lean
@@ -112,14 +112,6 @@ elab doc:(docComment)?
     "AnonymousComputeLemmasList" name:ident ":=" args:ident* : command =>
   anonymousComputeLemmasListsExt.defineDeclList doc name args
 
--- /-- Register a list of anonymous compute lemmas. -/
--- /-- Kept for backwards compatibility -/
-elab doc:(docComment)?
-    "AnonymousComputeLemmasLemmasList" name:ident ":=" args:ident* : command => do
-  logWarning ("AnonymousComputeLemmasLemmasList is deprecated, " ++
-    "use AnonymousComputeLemmasList instead")
-  anonymousComputeLemmasListsExt.defineDeclList doc name args
-
 /-! ##  Unfoldable definitions lists extension -/
 
 registerDeclListExtension unfoldableDefsListsExt


### PR DESCRIPTION
Fixes a few small typos, especially regarding the `#anonymous_goal_splitting_lemmas_lists` the command that was there was probably not intended, and now suggested to be changed to `#anonymous_compute_lemmas_lists`

Even less important: the syntax `AnonymousComputeLemmasLemmasList` was not very homogeneous with the rest of the commands, and I added a suggestion `AnonymousComputeLemmasList`.